### PR TITLE
Made AsyncApiSchemaOptions inherit from JsonSchemaGeneratorSettings

### DIFF
--- a/src/Saunter/AsyncApiOptions.cs
+++ b/src/Saunter/AsyncApiOptions.cs
@@ -88,7 +88,7 @@ namespace Saunter
         public AsyncApiSchemaOptions SchemaOptions { get; set; } = new AsyncApiSchemaOptions();
     }
 
-    public class AsyncApiSchemaOptions : NewtonsoftJsonSchemaGeneratorSettings
+    public class AsyncApiSchemaOptions : JsonSchemaGeneratorSettings
     {
         public AsyncApiSchemaOptions()
         {


### PR DESCRIPTION
Recent change to NewtonsoftJsonSchemaGeneratorSettings does not allow compatibility with System.Text.Json and forces users of the saunter library to introduce newtonsoft into their projects.

@m-wild 